### PR TITLE
Styling changes for input file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuhuinc/yuhui",
-  "version": "0.1.12-rc.5",
+  "version": "0.1.12-rc.6",
   "main": "dist/index.js",
   "scripts": {
     "build": "rm -rf dist/ && tsc",

--- a/src/Input/InputFile.tsx
+++ b/src/Input/InputFile.tsx
@@ -112,7 +112,7 @@ export interface InputFileProps extends WithContentProps {
   newFiles: any;
   onChange: any;
   onDropVerbiage: string;
-  dropFileVeriage: string;
+  dropFileVerbiage: string;
   browseVerbiage: string;
   acceptedFiles?: string;
   rejectFileError?: string;

--- a/src/Input/InputFile.tsx
+++ b/src/Input/InputFile.tsx
@@ -34,6 +34,9 @@ const StyledDropzoneText = styled.p`
   justify-content: ${props => (props.filesUploaded ? "space-between" : "auto")};
   line-height: 25px;
   margin: 10px 20px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const StyledDropHereText = styled.span`
@@ -44,10 +47,26 @@ const StyledDropHereText = styled.span`
     props.isDragActive
       ? props.theme?.colors?.secondary?.medium || colors.PURE_BLUE
       : props.theme?.colors?.grey?.dark || colors.SLATE_GREY};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  margin-right: 10px;
+`;
+
+const StyledSpan = styled.span`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  margin-right: 10px;
+  display: inline-block;
 `;
 
 const StyledBrowseFileText = styled.span`
   color: ${props => props.theme?.colors?.secondary?.medium || colors.PURE_BLUE};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  margin-right: 10px;
 `;
 
 const StyledFileContainer = styled.div`
@@ -64,10 +83,13 @@ const StyledFileContainer = styled.div`
 const StyledFileNames = styled.a`
   color: #65666d;
   text-decoration: none !important;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const StyledRemoveButton = styled.button`
-  width: 5%;
+  padding-top: 4px;
   border: none;
   font-size: 20px;
   background-color: transparent;
@@ -173,44 +195,6 @@ export const InputFile: InputFile = ({
 
   return (
     <StyledOuterContainer theme={theme} {...rest}>
-      {files.map(file => (
-        <StyledFileContainer theme={theme}>
-          <StyledFileNames
-            href={file.src}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {file.name}
-          </StyledFileNames>
-          <StyledRemoveButton
-            type="button"
-            onClick={removeFile(file)}
-            theme={theme}
-          >
-            <AiOutlineClose />
-          </StyledRemoveButton>
-        </StyledFileContainer>
-      ))}
-      {uploadedFiles.map(file =>
-        file.keep === false ? null : (
-          <StyledFileContainer theme={theme}>
-            <StyledFileNames
-              href={file.src}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {file.name}
-            </StyledFileNames>
-            <StyledRemoveButton
-              type="button"
-              onClick={removeUploadedFiles(file)}
-              theme={theme}
-            >
-              <AiOutlineClose />
-            </StyledRemoveButton>
-          </StyledFileContainer>
-        )
-      )}
       <StyledContainer
         {...getRootProps({ isDragActive })}
         theme={theme}
@@ -225,7 +209,7 @@ export const InputFile: InputFile = ({
           <StyledDropzoneText theme={theme} filesUploaded={filesUploaded}>
             <StyledDropHereText theme={theme} filesUploaded={filesUploaded}>
               <StyledDropIcon src={fileDropIcon} />
-              {dropFileVeriage}
+              <StyledSpan>{dropFileVeriage}</StyledSpan>
             </StyledDropHereText>
             <StyledBrowseFileText theme={theme}>
               {browseVerbiage}
@@ -233,6 +217,48 @@ export const InputFile: InputFile = ({
           </StyledDropzoneText>
         )}
       </StyledContainer>
+      {files.map(file => (
+        <StyledFileContainer theme={theme} key={`uploaded-file-btn-${file.id}`}>
+          <StyledFileNames
+            key={`uploaded-file-name-${file.id}`}
+            href={file.src}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {file.name}
+          </StyledFileNames>
+          <StyledRemoveButton
+            key={`uploaded-file-remove-${file.id}`}
+            type="button"
+            onClick={removeFile(file)}
+            theme={theme}
+          >
+            <AiOutlineClose />
+          </StyledRemoveButton>
+        </StyledFileContainer>
+      ))}
+      {uploadedFiles.map(file =>
+        file.keep === false ? null : (
+          <StyledFileContainer theme={theme} key={`file-btn-${file.id}`}>
+            <StyledFileNames
+              key={`file-name-${file.id}`}
+              href={file.src}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {file.name}
+            </StyledFileNames>
+            <StyledRemoveButton
+              key={`file-remove-btn-${file.id}`}
+              type="button"
+              onClick={removeUploadedFiles(file)}
+              theme={theme}
+            >
+              <AiOutlineClose />
+            </StyledRemoveButton>
+          </StyledFileContainer>
+        )
+      )}
       {rejectedFiles.length > 0 && <StyledError>{rejectFileError}</StyledError>}
     </StyledOuterContainer>
   );

--- a/src/Input/InputFile.tsx
+++ b/src/Input/InputFile.tsx
@@ -128,7 +128,7 @@ export const InputFile: InputFile = ({
   data,
   onChange,
   onDropVerbiage,
-  dropFileVeriage,
+  dropFileVerbiage,
   browseVerbiage,
   acceptedFiles,
   rejectFileError,
@@ -209,7 +209,7 @@ export const InputFile: InputFile = ({
           <StyledDropzoneText theme={theme} filesUploaded={filesUploaded}>
             <StyledDropHereText theme={theme} filesUploaded={filesUploaded}>
               <StyledDropIcon src={fileDropIcon} />
-              <StyledSpan>{dropFileVeriage}</StyledSpan>
+              <StyledSpan>{dropFileVerbiage}</StyledSpan>
             </StyledDropHereText>
             <StyledBrowseFileText theme={theme}>
               {browseVerbiage}

--- a/stories/components/Input/InputFile.stories.tsx
+++ b/stories/components/Input/InputFile.stories.tsx
@@ -51,12 +51,14 @@ const content = {
 
 const uploadedFiles = [
   {
+    id: 1,
     name: "file1.txt",
     src: "https://www.google.ca",
     file_type: "text/plain",
     keep: true
   },
   {
+    id: 2,
     name: "file1.txt",
     src: "https://www.google.ca",
     file_type: "text/plain",

--- a/stories/components/Input/InputFile.stories.tsx
+++ b/stories/components/Input/InputFile.stories.tsx
@@ -96,7 +96,7 @@ export const InputFiles = () => {
               }}
               contentKey="demo.placeholder" // not used in component
               onDropVerbiage="Drop file here"
-              dropFileVeriage="Drag and drop files here"
+              dropFileVerbiage="Drag and drop files here"
               browseVerbiage="Or browse files"
               rejectFileError="Cannot accept that file"
               acceptedFiles="application/pdf, image/*, text/plain, .zip, .doc"


### PR DESCRIPTION
- Adding text overflow to InputFile component when width is small (for when component is used in mobile view)
- Moved the drag and drop component above the list of uploaded files (Hannah's request)
- Regarding the text in mobile view, it can be adjusted when the component is being used.
For example, if mobile view, don't pass anything to browseVerbiage prop then only dropFileVerbiage will be used and can pass necessary string for mobile view.
- Also added keys into the lists to remove browser errors


![Screen Shot 2020-04-01 at 5 21 21 PM](https://user-images.githubusercontent.com/38918700/78188122-b19e7380-743d-11ea-8339-d1559ac57a2a.png)
![Screen Shot 2020-04-01 at 5 21 46 PM](https://user-images.githubusercontent.com/38918700/78188123-b2370a00-743d-11ea-8dcc-f88b170d85e7.png)

### when browseVerbiage is removed and only dropFileVerbiage is passed
![Screen Shot 2020-04-01 at 5 25 44 PM](https://user-images.githubusercontent.com/38918700/78188262-ec081080-743d-11ea-88ae-eb4cd1bb451c.png)
